### PR TITLE
Avoid an intersection type as pattern of a match type.

### DIFF
--- a/dotty/derivation/src/main/scala/perspective/derivation/Helpers.scala
+++ b/dotty/derivation/src/main/scala/perspective/derivation/Helpers.scala
@@ -13,8 +13,12 @@ object Helpers {
   }
 
   type TupleUnionLub[T <: Tuple, Lub, Acc <: Lub] <: Lub = T match {
-    case (h & Lub) *: t => TupleUnionLub[t, Lub, Acc | h]
-    case EmptyTuple     => Acc
+    case h *: t =>
+      h match {
+        case Lub => TupleUnionLub[t, Lub, Acc | (h & Lub)]
+      }
+    case EmptyTuple =>
+      Acc
   }
 
   type TupleUnion[T <: Tuple, Acc] = T match {


### PR DESCRIPTION
Such patterns are non-deterministic, since there are several possible answers for `h` that satisfy the constraints. They may be warned against in the future.